### PR TITLE
Update guacamole.conf.template

### DIFF
--- a/nginx/templates/guacamole.conf.template
+++ b/nginx/templates/guacamole.conf.template
@@ -1,6 +1,7 @@
 ### BBB
 server {
-    listen       443 ssl http2;
+    listen       443 ssl;
+    http2  on;
     server_name  localhost;
 
         ssl_certificate /etc/nginx/ssl/self.cert;


### PR DESCRIPTION
removed deprecated http2 option from listen and added separate config option for it (line 3 and 4)